### PR TITLE
(fix) Pass `defaultHour` and `defaultMinute` to flatpickr

### DIFF
--- a/addon/components/ember-flatpickr.js
+++ b/addon/components/ember-flatpickr.js
@@ -105,6 +105,8 @@ export default TextField.extend({
         'clickOpens',
         'dateFormat',
         'defaultDate',
+        'defaultHour',
+        'defaultMinute',
         'disable',
         'disableMobile',
         'enable',


### PR DESCRIPTION
I haven't supplied defaults in `ember-flatpickr`; flatpickr will provide its own defaults if the values are `undefined`.