### PR TITLE
Adding test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,35 @@ All options available to Flatpickr are available here.
 
 Please see the [flatpickr docs](https://chmln.github.io/flatpickr/) for a full list of options.
 
+## Test Helpers
+
+Ember-flatpickr ships with a few [test-helpers](addon-test-support/helpers.js) to make your test cases a little bit DRYer.
+
+#### For Acceptance Tests:
+Import `helpers.js` into `.../test/helpers/start-app.js` and call the default function in order to register your helpers. 
+```javascript
+// .../test/helpers/start-app.js
+
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
+import Application from '../../app';
+import config from '../../config/environment';
+import registerFlatpickrHelpers from 'ember-flatpickr/test-support/helpers';
+
+registerFlatpickrHelpers();
+
+export default function startApp(attrs) {
+  //...
+}
+```
+Once registered, the helpers can be called directly in your acceptance tests without having to import anything.
+
+#### For Integration Tests:
+Simply import the specific helpers you need at the top of your test file.
+```javascript
+import { setFlatpickrDate, isFlatpickrOpen } from 'ember-flatpickr/test-support/helpers';
+```
+
 ## Contributing
 
 If there are features you would like to see implemented, or we have missed some flatpickr options, please open an issue and/or submit a PR!

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -1,0 +1,51 @@
+import { registerHelper } from '@ember/test';
+import { find } from 'ember-native-dom-helpers';
+
+/**
+ * Checks if the flatpickr calendar is being displayed.
+ * @param {Number} [pickrIndex=0] - Index of flatpickr calendar to be targeted (for when multiple exist)
+ * @returns {Boolean}
+*/
+export function isFlatpickrOpen(pickrIndex = 0) {
+  const flatpickerCal = document.getElementsByClassName('flatpickr-calendar')[pickrIndex];
+  return flatpickerCal.classList.contains('open');
+}
+
+/**
+ * @param {String} selector - CSS3 selector of the element to pull the flatpickr instance from
+ * @param {Object} date - A Date Object or array of Date Objects to set as the selected date(s)
+ * @param {Boolean} [triggerChange=true] - If true, this forces onChange events to fire
+*/
+export function setFlatpickrDate(selector, date, triggerChange = true) {
+  const flatpickrInput = find(selector);
+  if (!flatpickrInput) _throwSelectorError(selector, 'setFlatpickrDate');
+  flatpickrInput._flatpickr.setDate(date, triggerChange);
+}
+
+/**
+ * Clears out the flatpickr selectedDates attribute as well as the associated input.
+ * @param {String} selector - CSS3 selector of the element to pull the flatpickr instance from
+*/
+export function clearFlatpickrDate(selector) {
+  const flatpickrInput = find(selector);
+  if (!flatpickrInput) _throwSelectorError(selector, 'clearFlatpickrDate');
+  flatpickrInput._flatpickr.clear();
+}
+
+// Registers helpers for acceptance tests
+
+export default function () {
+  registerHelper('setFlatpickrDate', function(app, selector, date, triggerChange) {
+    return setFlatpickrDate(selector, date, triggerChange);
+  });
+
+  registerHelper('clearFlatpickrDate', function(app, selector) {
+    return clearFlatpickrDate(selector);
+  });
+}
+
+function _throwSelectorError(selector, functionName) {
+  throw new Error(
+    `${functionName}() - No input was found using selector '${selector}'`
+  );
+}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-power-select": "^1.9.2",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.17.0-beta.1",
-    "eslint-plugin-ember": "^4.3.0",
+    "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-ship-shape": "^0.4.0",
     "flexi": "2.0.2",
     "loader.js": "^4.2.3"


### PR DESCRIPTION
I've been using ember-flatpickr a bit in my latest project and I've found myself repeating a few patterns when writing tests that involve the library. In an effort to keep things organized and hopefully set precedent for any future test helpers, I've converted my personal helpers into an add-on test-support file. I've also updated the ReadMe to with basic usage instructions (I've left out usage for each specific helper as I think the JS annotations have that covered).

These helpers aren't anything monumental but I figure they can spark some discussion, at the very least. Let me know what you think.

