### PR TITLE
ember-flatpickr now observes changes to altFormat attr

### DIFF
--- a/addon/components/ember-flatpickr.js
+++ b/addon/components/ember-flatpickr.js
@@ -50,8 +50,12 @@ export default Component.extend({
     });
   }),
 
-  didReceiveAttrs: diffAttrs('date', 'disabled', 'locale', 'maxDate', 'minDate', function(changedAttrs, ...args) {
+  didReceiveAttrs: diffAttrs('altFormat', 'date', 'disabled', 'locale', 'maxDate', 'minDate', function(changedAttrs, ...args) {
     this._super(...args);
+    
+    this._attributeHasChanged(changedAttrs, 'altFormat', (newAltFormat) => {
+      this.element._flatpickr.set('altFormat', newAltFormat);
+    });
 
     this._attributeHasChanged(changedAttrs, 'date', (newDate) => {
       if (typeof newDate !== 'undefined') {

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -66,7 +66,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
     assert.equal(find('.flatpickr-input[type="text"]').disabled, false, 'text input not disabled');
   });
 
-  test('altFormat updates when changd', async function(assert) {
+  test('altFormat updates when changed', async function(assert) {
     assert.expect(2);
 
     this.actions.onChange = () => {

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -66,6 +66,31 @@ module('Integration | Component | ember flatpickr', function(hooks) {
     assert.equal(find('.flatpickr-input[type="text"]').disabled, false, 'text input not disabled');
   });
 
+  test('altFormat updates when changd', async function(assert) {
+    assert.expect(2);
+
+    this.actions.onChange = () => {
+    };
+
+    this.set('dateValue', '2080-12-01T16:16:22.585Z');
+    this.set('altFormat', 'j'); // 1-31 (day of month, no leading zeros)
+
+    await render(hbs`{{ember-flatpickr
+      altInput=true
+      altFormat=altFormat
+      date=(readonly dateValue)
+      flatpickrRef=flatpickrRef
+      onChange="onChange"
+      placeholder="Pick date"
+      }}`);
+
+    assert.equal(find('.flatpickr-input[type="text"]').value, '1', 'initial altFormat value');
+
+    this.set('altFormat', 'Y');
+
+    assert.equal(find('.flatpickr-input[type="text"]').value, '2080', 'altFormat updates when changed');
+  });
+
   test('value updates when set externally via flatpickrRef', async function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
Fixes https://github.com/shipshapecode/ember-flatpickr/issues/255

So the test actually fails because flatpickr itself doesn't currently update altFormat for some reason. I have made them aware of the issue here;
https://github.com/flatpickr/flatpickr/issues/1431

So this PR is just in preparation for when that issue is fixed - it should work once that's done.

-----

Unrelated, a different test about locales was failing too
```
not ok 16 Chrome 67.0 - Integration | Component | ember flatpickr: locale works correctly
actual: > décembre
expected: >Décembre
```