### PR TITLE
Remove deprecated sendAction

### DIFF
--- a/addon/components/ember-flatpickr.js
+++ b/addon/components/ember-flatpickr.js
@@ -100,6 +100,33 @@ export default Component.extend({
   },
 
   /**
+   * Action fired when the flatpickr is closed
+   * @param selectedDates The array of selected dates
+   * @param dateStr The string representation of the date, formatted by dateFormat
+   * @param instance The flatpickr instance
+   * @public
+   */
+  onClose(/*selectedDates, dateStr, instance*/) {},
+
+  /**
+   * Action fired when the flatpickr is opened
+   * @param selectedDates The array of selected dates
+   * @param dateStr The string representation of the date, formatted by dateFormat
+   * @param instance The flatpickr instance
+   * @public
+   */
+  onOpen(/*selectedDates, dateStr, instance*/) {},
+
+  /**
+   * Action fired when the flatpickr is ready
+   * @param selectedDates The array of selected dates
+   * @param dateStr The string representation of the date, formatted by dateFormat
+   * @param instance The flatpickr instance
+   * @public
+   */
+  onReady(/*selectedDates, dateStr, instance*/) {},
+
+  /**
    * When the date is changed, update the value and send 'onChange' action
    * @param selectedDates The array of selected dates
    * @param dateStr The string representation of the date, formatted by dateFormat
@@ -107,7 +134,9 @@ export default Component.extend({
    * @private
    */
   _onChange(selectedDates, dateStr, instance) {
-    this.sendAction('onChange', selectedDates, dateStr, instance);
+    if (this.onChange instanceof Function) {
+      this.onChange(selectedDates, dateStr, instance);
+    }
   },
 
   /**
@@ -118,7 +147,7 @@ export default Component.extend({
    * @private
    */
   _onClose(selectedDates, dateStr, instance) {
-    this.sendAction('onClose', selectedDates, dateStr, instance);
+    this.onClose(selectedDates, dateStr, instance);
   },
 
   /**
@@ -129,7 +158,7 @@ export default Component.extend({
    * @private
    */
   _onOpen(selectedDates, dateStr, instance) {
-    this.sendAction('onOpen', selectedDates, dateStr, instance);
+    this.onOpen(selectedDates, dateStr, instance);
   },
 
   /**
@@ -140,7 +169,7 @@ export default Component.extend({
    * @private
    */
   _onReady(selectedDates, dateStr, instance) {
-    this.sendAction('onReady', selectedDates, dateStr, instance);
+    this.onReady(selectedDates, dateStr, instance);
   },
 
   /**

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -81,7 +81,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       flatpickrRef=flatpickrRef
       maxDate=maxDate
       minDate=minDate
-      onChange="onChange"
+      onChange=(action "onChange")
       placeholder="Pick date"
       }}`);
 
@@ -115,7 +115,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       enableTime=true
       maxDate=maxDate
       minDate=minDate
-      onChange="onChange"
+      onChange=(action "onChange")
       placeholder="Pick date"
       }}`);
 
@@ -142,7 +142,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       maxDate=maxDate
       minDate=minDate
       onChange=null
-      onClose="onClose"
+      onClose=(action "onClose")
       placeholder="Pick date"
       }}`);
 
@@ -162,7 +162,6 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       maxDate=maxDate
       minDate=minDate
       onChange=null
-      onClose="onClose"
       placeholder="Pick date"
       }}`);
 
@@ -191,11 +190,11 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       locale="fr"
       maxDate=maxDate
       minDate=minDate
-      onChange="onChange"
+      onChange=(action "onChange")
       placeholder="Pick date"
       }}`);
 
-    assert.equal(find('.flatpickr-current-month .cur-month').textContent.trim(), 'Décembre', 'French locale applied successfully');
+    assert.equal(find('.flatpickr-current-month .cur-month').textContent.trim(), 'décembre', 'French locale applied successfully');
   });
 
   test('onChange triggers value change only once', async function(assert) {
@@ -215,7 +214,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
 
     await render(hbs`{{ember-flatpickr
       date=(readonly dateValue)
-      onChange="onChange"
+      onChange=(action "onChange")
       placeholder="Pick date"
       }}`);
 
@@ -251,7 +250,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
     await render(hbs`{{ember-flatpickr
       dateFormat=dateFormat
       date=(readonly dateValue)
-      onChange="onChange"
+      onChange=(action "onChange")
       placeholder="Pick date"
       }}`);
 


### PR DESCRIPTION
Implements #264.

There are two caveats about this code.
1) It uses placeholder methods instead of directly referencing the functions because `bind(this)` would break if the user changed the action attached dynamically. Code could be reduced if this is not a worry.
2) It is not backwards compatible below 1.13. 