### PR TITLE
_findHost in included for third addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,21 @@
-"use strict";
+'use strict';
 
-const fastbootTransform = require("fastboot-transform");
+const fastbootTransform = require('fastboot-transform');
 
 module.exports = {
-  name: require("./package").name,
+  name: require('./package').name,
   options: {
     nodeAssets: {
       flatpickr() {
         const localePaths = this.locales.map(locale => `l10n/${locale}.js`);
 
         return {
-          srcDir: "dist",
+          srcDir: 'dist',
           import: {
-            include: ["flatpickr.js", this.theme || "flatpickr.css"].concat(localePaths),
+            include: [
+              'flatpickr.js',
+              this.theme || 'flatpickr.css'
+            ].concat(localePaths),
             processTree(tree) {
               return fastbootTransform(tree);
             }
@@ -27,7 +30,7 @@ module.exports = {
 
     // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
     // use that.
-    if (typeof this._findHost === "function") {
+    if (typeof this._findHost === 'function') {
       app = this._findHost();
     } else {
       // Otherwise, we'll use this implementation borrowed from the _findHost()

--- a/index.js
+++ b/index.js
@@ -1,21 +1,18 @@
-'use strict';
+"use strict";
 
-const fastbootTransform = require('fastboot-transform');
+const fastbootTransform = require("fastboot-transform");
 
 module.exports = {
-  name: require('./package').name,
+  name: require("./package").name,
   options: {
     nodeAssets: {
       flatpickr() {
         const localePaths = this.locales.map(locale => `l10n/${locale}.js`);
 
         return {
-          srcDir: 'dist',
+          srcDir: "dist",
           import: {
-            include: [
-              'flatpickr.js',
-              this.theme || 'flatpickr.css'
-            ].concat(localePaths),
+            include: ["flatpickr.js", this.theme || "flatpickr.css"].concat(localePaths),
             processTree(tree) {
               return fastbootTransform(tree);
             }
@@ -25,7 +22,22 @@ module.exports = {
     }
   },
 
-  included(app) {
+  included() {
+    let app;
+
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === "function") {
+      app = this._findHost();
+    } else {
+      // Otherwise, we'll use this implementation borrowed from the _findHost()
+      // method in ember-cli.
+      let current = this;
+      do {
+        app = current.app || app;
+      } while (current.parent.parent && (current = current.parent));
+    }
+
     if (app.options && app.options.flatpickr && app.options.flatpickr.theme) {
       this.theme = `themes/${app.options.flatpickr.theme}.css`;
     }


### PR DESCRIPTION
In order to let other ui libs such as `ember-paper` use `ember-flatpickr` via third addons integrations like `ember-paper-flatpickr` the host app via `ember-cli-build.js` should be able to define `flatpickr` options, like the theme or locales, as normal `ember-flatpickr` do... so this PR makes sure we find the host app, so we can access the `app.options.flatpickr` options.

It's actually a copy paste from `ember-paper` `include` hook. 