### PR TITLE
Allow flatpickrRef access via an action

### DIFF
--- a/addon/mixins/flatpickr.js
+++ b/addon/mixins/flatpickr.js
@@ -51,6 +51,9 @@ export default Mixin.create({
       this._setDisabled(this.get("disabled"));
 
       this.set("flatpickrRef", flatpickrRef);
+      if (this.get("getFlatpickrRef")) {
+        this.get("getFlatpickrRef")(flatpickrRef);
+      }
     });
   },
 

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -17,7 +17,8 @@
   enable=datesToEnable
   enableSeconds=false
   enableTime=true
-  flatpickrRef=flatpickrRef
+  flatpickrRef=flatpickrRef   // two-way binding
+  getFlatpickrRef=(action (mut flatpickrRef))  // via action (prefered)
   hourIncrement=1
   inline=false
   locale='ru'
@@ -140,7 +141,7 @@ Check [flatpickr locale documentation](https://chmln.github.io/flatpickr/#locale
 
 ## flatpickrRef
 
-If you need to interact directly with the flatpickr instance you have created inside the component, you can pass in `flatpickrRef=myFlatpickrRefName`, which would then be accesible in the controller or parent component. You can then do things like `this.get('myFlatpickrRefName').close()` to close the datepicker, if you wanted to make a close button.
+If you need to interact directly with the flatpickr instance you have created inside the component, you can use the action `getFlatpickrRef` as `getFlatpickrRef=(action (mut flatpickrRef))`, which would then be accesible in the controller or parent component. You can then do things like `this.get('myFlatpickrRefName').close()` to close the datepicker, if you wanted to make a close button.
 
 ## Options
 

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -79,7 +79,6 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       altInput=true
       altFormat=altFormat
       date=(readonly dateValue)
-      flatpickrRef=flatpickrRef
       onChange="onChange"
       placeholder="Pick date"
       }}`);
@@ -89,6 +88,35 @@ module('Integration | Component | ember flatpickr', function(hooks) {
     this.set('altFormat', 'Y');
 
     assert.equal(find('.flatpickr-input[type="text"]').value, '2080', 'altFormat updates when changed');
+  });
+
+  test('flatpickrRef is accessible', async function(assert) {
+    assert.expect(2);
+
+    this.actions.onChange = () => {
+    };
+
+    this.set('dateValue', '2080-12-01T16:16:22.585Z');
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      flatpickrRef=flatpickrRef
+      onChange=(action "onChange")
+      placeholder="Pick date"
+      }}`);
+
+    assert.ok(this.flatpickrRef, 'flatpickrRef set via 2-way binding');
+
+    this.set("flatpickrRef", undefined);
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      onChange=(action "onChange")
+      getFlatpickrRef=(action (mut flatpickrRef))
+      placeholder="Pick date"
+      }}`);
+
+    assert.ok(this.flatpickrRef, 'flatpickrRef set via action');
   });
 
   test('value updates when set externally via flatpickrRef', async function(assert) {
@@ -103,7 +131,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
 
     await render(hbs`{{ember-flatpickr
       date=(readonly dateValue)
-      flatpickrRef=flatpickrRef
+      getFlatpickrRef=(action (mut flatpickrRef))
       maxDate=maxDate
       minDate=minDate
       onChange=(action "onChange")
@@ -330,7 +358,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       date=(readonly dateValue)
       onChange=(action (mut dateValue))
       placeholder="Pick date"
-      flatpickrRef=flatpickrRef
+      getFlatpickrRef=(action (mut flatpickrRef))
       }}`);
 
     assert.equal(this.get('flatpickrRef').selectedDates.length, 1, '1 date is selected');
@@ -348,7 +376,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       date=(readonly dateValue)
       onChange=(action (mut dateValue))
       placeholder="Pick date"
-      flatpickrRef=flatpickrRef
+      getFlatpickrRef=(action (mut flatpickrRef))
       }}`);
 
     assert.equal(this.get('flatpickrRef').selectedDates.length, 1, '1 date is selected');
@@ -366,7 +394,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
       date=(readonly dateValue)
       onChange=(action (mut dateValue))
       placeholder="Pick date"
-      flatpickrRef=flatpickrRef
+      getFlatpickrRef=(action (mut flatpickrRef))
       }}`);
 
     assert.equal(this.get('flatpickrRef').selectedDates.length, 1, '1 date is selected');
@@ -383,7 +411,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
     date=(readonly dateValue)
     onChange=(action (mut dateValue))
     placeholder="Pick date"
-    flatpickrRef=flatpickrRef
+      getFlatpickrRef=(action (mut flatpickrRef))
     }}`);
 
     assert.equal(this.get('flatpickrRef').selectedDates.length, 1, '1 date is selected');


### PR DESCRIPTION
Currently access to the flatpickrRef is only done via two-way binding which is against DDAU. This also prevents the component being used with angle-bracket syntax.

Created an action onFlatpickrRef to replace the two-way binding.