### PR TITLE
Prevent wrap. Provide documentation

### DIFF
--- a/addon/mixins/flatpickr.js
+++ b/addon/mixins/flatpickr.js
@@ -24,6 +24,12 @@ export default Mixin.create({
       this.get("onChange") !== undefined
     );
 
+    // Wrap is not supported
+    assert(
+      "{{ember-flatpickr}} does not support the wrap option. Please see documentation for an alternative.",
+      this.attrs.wrap !== true
+    );
+
     // Pass all values and setup flatpickr
     run.scheduleOnce("afterRender", this, function() {
       const fastboot = getOwner(this).lookup("service:fastboot");

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -39,7 +39,6 @@
   static=false
   time_24hr=false
   weekNumbers=false
-  wrap=false
 }}
 ```
 
@@ -145,6 +144,36 @@ If you need to interact directly with the flatpickr instance you have created in
 
 ## Options
 
-All options available to Flatpickr are available here.
+All options available to Flatpickr are available here with the exception of wrap.
+
+## ember-flatpickr and external elements
+
+The wrap option for flatpickr causes flatpickr to search its child elements for elements annotated with certain attributes. With ember-flatpickr this can be accomplished with the following
+
+```handlebars
+{{ember-flatpickr
+onChange=(action (mut dateValue))
+getFlatpickrRef=(action (mut flatpickrRef))
+}}
+
+<a class="input-button" title="toggle" onclick={{action "toggleCalendar"}}>
+    <i class="icon-calendar"></i>
+</a>
+
+<a class="input-button" title="clear" onclick={{action "clearCalendar"}}>
+    <i class="icon-close"></i>
+</a>
+```
+ 
+```javascript
+  actions: {
+    toggleCalendar() {
+      this.flatpickrRef.toggle();
+    },
+    clearCalendar() {
+      this.flatpickrRef.clear();
+    }
+  }
+```
 
 Please see the [flatpickr docs](https://chmln.github.io/flatpickr/) for a full list of options.


### PR DESCRIPTION
The wrap option, if passed as true to flatpickr, will fail with an error because ember-flatpickr has not ability to attach to a parent element. I played with what it would take to make this feasible and it just complicated the component needlessly. Considering that the same thing could be done easily, I updated the documentation with an example, and added an assert on wrap=true (since it would fail) and pointed the user to the documentation.