### PR TITLE
🌐♻️📝Adding Some ARIA Support + Extending Ember TextField + Docs

### DIFF
--- a/addon/components/ember-flatpickr.js
+++ b/addon/components/ember-flatpickr.js
@@ -1,10 +1,73 @@
-import Component from '@ember/component';
-import Flatpickr from 'ember-flatpickr/mixins/flatpickr';
+/** @documenter yuidoc */
 
-export default Component.extend(Flatpickr, {
-  tagName: 'input',
-  type: "text",
-  attributeBindings: ["placeholder", "type"],
+import Flatpickr from 'ember-flatpickr/mixins/flatpickr';
+import TextField from '@ember/component/text-field';
+
+/**
+ * Ember component that wraps the lightweight [`flatpickr`](https://flatpickr.js.org) datetime
+ * chooser.
+ *
+ * This component extends Ember's `@ember/component/text-field` and mixes
+ * in `ember-flatpickr/mixins/flatpickr`.
+ *
+ * ```handlebars
+ *  {{ember-flatpickr
+ *    date=(readonly model.someDate)
+ *  }}
+ * ```
+ *
+ * Or using angle brackets:
+ *
+ * ```handlebars
+ *  <EmberFlatpickr @date={{readonly model.someDate}}/>
+ * ```
+ *
+ * @class EmberFlatpickr
+ * @element ember-flatpickr
+ * @extends TextField
+ * @public
+ * @uses Flatpickr
+ */
+export default TextField.extend(Flatpickr, {
+  /**
+   * ARIA bindings for a textbox.
+   * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/textbox_role
+   * @see https://labs.levelaccess.com/index.php/Category:ARIA
+   */
+  attributeBindings: [
+    'aria-activedescendent',
+    'aria-autocomplete',
+    'aria-describedby',
+    'aria-labelledby',
+    'aria-multiline',
+    'aria-placeholder',
+    'aria-readonly',
+    'aria-required'
+  ],
+
+  /**
+   * The date(s) that will be used to initialize the flatpickr.  When present, the date(s) will
+   * be formatted accordingly.
+   *
+   * Supply one of the following:
+   *  * A single dateObject
+   *  * A single string containing a date formatted accordingly to dateFormat
+   *  * An array of dateObject
+   *  * An array of string containing dates formatted accordingly to dateFormat
+   *
+   * @argument date
+   * @type {Array<Date>|Array<String>|Date|String}
+   */
+
+  /**
+   * A string of characters which are used to define how the date will be displayed in the input box.
+   *
+   * [The supported characters are defined here.](https://flatpickr.js.org/formatting/)
+   *
+   * @argument dateFormat
+   * @type {String}
+   */
+
   didInsertElement() {
     this._super(...arguments);
     this.set('field', this.element);

--- a/addon/mixins/flatpickr.js
+++ b/addon/mixins/flatpickr.js
@@ -1,3 +1,4 @@
+/** @documenter yuidoc */
 
 /* eslint-disable ember/closure-actions, ember/no-attrs-in-components, ember/no-on-calls-in-components */
 import Mixin from "@ember/object/mixin";
@@ -7,8 +8,15 @@ import { run } from "@ember/runloop";
 import { getOwner } from "@ember/application";
 import diffAttrs from 'ember-diff-attrs';
 
+/**
+ * The mixin responsible for incorporating the [`flatpickr`](https://flatpickr.js.org)
+ * features into an input/element.
+ *
+ * @class Flatpickr
+ */
 export default Mixin.create({
   date: null,
+
   flatpickrRef: null,
 
   setupFlatpickr() {
@@ -117,10 +125,60 @@ export default Mixin.create({
     }
   },
 
+  /**
+   * Triggered when the user selects a date, or changes the time on a selected date.
+   *
+   * @method onClose
+   * @param {Array} selectedDates an array of Date objects selected by the user. When there are
+   * no dates selected, the array is empty.
+   * @param {String} dateStr a string representation of the latest selected Date object by the
+   * user. The string is formatted as per the dateFormat option
+   * @param {Object} instance the flatpickr object, containing various methods and properties.
+   * @type {Action}
+   * @return {void}
+   */
+  onChange(/*selectedDates, dateStr, instance*/) {},
+
+  /**
+   * Triggered when the calendar is closed.
+   *
+   * @method onClose
+   * @param {Array} selectedDates an array of Date objects selected by the user. When there are
+   * no dates selected, the array is empty.
+   * @param {String} dateStr a string representation of the latest selected Date object by the
+   * user. The string is formatted as per the dateFormat option
+   * @param {Object} instance the flatpickr object, containing various methods and properties.
+   * @type {Action}
+   * @return {void}
+   */
   onClose(/*selectedDates, dateStr, instance*/) {},
 
+  /**
+   * Triggered when the calendar is closed.
+   *
+   * @method onOpen
+   * @param {Array} selectedDates an array of Date objects selected by the user. When there are
+   * no dates selected, the array is empty.
+   * @param {String} dateStr a string representation of the latest selected Date object by the
+   * user. The string is formatted as per the dateFormat option
+   * @param {Object} instance the flatpickr object, containing various methods and properties.
+   * @type {Action}
+   * @return {void}
+   */
   onOpen(/*selectedDates, dateStr, instance*/) {},
 
+  /**
+   * Triggered once the calendar is in a ready state.
+   *
+   * @method onReady
+   * @param {Array} selectedDates an array of Date objects selected by the user. When there are
+   * no dates selected, the array is empty.
+   * @param {String} dateStr a string representation of the latest selected Date object by the
+   * user. The string is formatted as per the dateFormat option
+   * @param {Object} instance the flatpickr object, containing various methods and properties.
+   * @type {Action}
+   * @return {void}
+   */
   onReady(/*selectedDates, dateStr, instance*/) {},
 
   _onChange(selectedDates, dateStr, instance) {
@@ -143,6 +201,13 @@ export default Mixin.create({
 
   _setDisabled(disabled) {
     if (this.get("altInput")) {
+      // `this.field` is the hidden input storing the alternate date value sent to the server
+      // @see https://flatpickr.js.org/options/ `altInput` config options
+      // Refactored during https://github.com/shipshapecode/ember-flatpickr/issues/306 to instead
+      // extend Ember's `@ember/component/text-field`
+      this.field.disabled = !disabled;
+      // `this.field.nextSibling` is the text input that the user will interact with, so
+      // long as it is enabled
       this.field.nextSibling.disabled = disabled;
     } else {
       this.field.disabled = disabled;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^3.0.0",
     "codeclimate-test-reporter": "^0.5.1",
+    "ember-angle-bracket-invocation-polyfill": "^1.3.1",
     "ember-cli": "~3.10.1",
     "ember-cli-addon-docs": "^0.6.10",
     "ember-cli-addon-docs-yuidoc": "^0.2.1",

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -19,6 +19,132 @@ module('Integration | Component | ember flatpickr', function(hooks) {
     await triggerEvent(document.body, 'mousedown');
   }
 
+  test('when rendering with angle brackets', async function (assert) {
+    this.set('dateValue', [new Date(2001, 8, 11)]);
+
+    await render(hbs`<EmberFlatpickr @date={{readonly dateValue}}/>`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').value, '2001-09-11')
+  });
+
+  test('when adding aria-activedescendent attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      onChange=null
+      aria-activedescendent="aria-activedescendent"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('aria-activedescendent'), 'aria-activedescendent')
+  });
+
+  test('when adding aria-autocomplete attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      onChange=null
+      aria-autocomplete="aria-autocomplete"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('aria-autocomplete'), 'aria-autocomplete')
+  });
+
+  test('when adding aria-describedby attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+    date=(readonly dateValue)
+    onChange=null
+    aria-describedby="described by"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('aria-describedby'), 'described by')
+  });
+
+  test('when adding aria-labelledby attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      onChange=null
+      aria-labelledby="aria-labelledby"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('aria-labelledby'), 'aria-labelledby')
+  });
+
+  test('when adding aria-multiline attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      onChange=null
+      aria-multiline="aria-multiline"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('aria-multiline'), 'aria-multiline')
+  });
+
+  test('when adding aria-placeholder attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      onChange=null
+      aria-placeholder="aria-placeholder"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('aria-placeholder'), 'aria-placeholder')
+  });
+
+  test('when adding aria-readonly attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      onChange=null
+      aria-readonly="aria-readonly"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('aria-readonly'), 'aria-readonly')
+  });
+
+  test('when adding aria-required attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+      date=(readonly dateValue)
+      onChange=null
+      aria-required="aria-required"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('aria-required'), 'aria-required')
+  });
+
+  test('when adding a title attribute it is assigned to the picker input', async function (assert) {
+    this.set('dateValue', [new Date()]);
+
+    await render(hbs`{{ember-flatpickr
+    date=(readonly dateValue)
+    onChange=null
+    title="Choose a date"
+    }}`);
+
+    assert.equal(findAll('.flatpickr-input').length, 1);
+    assert.equal(find('.flatpickr-input').getAttribute('title'), 'Choose a date')
+  });
+
   test('disabled is updated when altInput=true', async function(assert) {
     assert.expect(4);
 

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -22,7 +22,7 @@ module('Integration | Component | ember flatpickr', function(hooks) {
   test('when rendering with angle brackets', async function (assert) {
     this.set('dateValue', [new Date(2001, 8, 11)]);
 
-    await render(hbs`<EmberFlatpickr @date={{readonly dateValue}}/>`);
+    await render(hbs`<EmberFlatpickr @date={{readonly dateValue}} />`);
 
     assert.equal(findAll('.flatpickr-input').length, 1);
     assert.equal(find('.flatpickr-input').value, '2001-09-11')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4447,6 +4447,15 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+ember-angle-bracket-invocation-polyfill@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.3.1.tgz#3dd0b91b3776a8048a943889c031fa7f9ea44ec4"
+  integrity sha512-eeE4LBFIxJ5EclTIydPMPs04vvSDv64m+1fxwN2UKdSdRDWwus36k4B/LquDfWuG1WI0Dk3R4WoTFcRYlbNTWg==
+  dependencies:
+    ember-cli-babel "^6.17.0"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.0.2"
+
 ember-app-scheduler@^1.0.5:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/ember-app-scheduler/-/ember-app-scheduler-1.0.8.tgz#37adacce2fa5ab59324e2c0b08f3c4a3568025b4"
@@ -4596,7 +4605,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -5107,7 +5116,7 @@ ember-code-snippet@^2.4.0:
     es6-promise "^1.0.0"
     glob "^7.1.3"
 
-ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0:
+ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
   integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==
@@ -5412,9 +5421,9 @@ ember-source-channel-url@^1.0.1, ember-source-channel-url@^1.1.0:
     got "^8.0.1"
 
 ember-source@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.10.0.tgz#c423f494d573d418bf843d605ea79c21a14ca863"
-  integrity sha512-qHI+1y1gcfHO44+Ld3ty9565UsqlmimfOLe/Ra3jA4Z9h6vJNOdIzr4Bws7by/8kiBqjO1RM+TVe19zglivwoQ==
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.10.1.tgz#f8b337aa9fa2aacab4dfcfb8460028730df9a84c"
+  integrity sha512-I6AJTuy05WruN77Fb6mXtrt68jPy0pXyfSGXhCzxJMZIfv03jJ89CiRnzkjk6W4YCxVqJnNZigqMxUAXogMcsA==
   dependencies:
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^3.0.2"


### PR DESCRIPTION
* Started by introducing ARIA attribute bindings
* Noticed that the `title` attribute wasn't bound to this control, thought it odd
* Instead of extending `Component` changed to extend `TextField` (I've done this many times in other projects)
* Extending `TextField` necessitated a small change in the `_setDisabled` when `altInput` is used
* fumbled around by adding some yuidoc