### PR TITLE
Remove `getFlatpickrRef` and `appendDataInput`, update flatpickr to 4.6.6

### DIFF
--- a/addon/components/ember-flatpickr.js
+++ b/addon/components/ember-flatpickr.js
@@ -106,7 +106,6 @@ export default class EmberFlatpickr extends Component {
 
     const {
       date,
-      getFlatpickrRef,
       disabled = false,
       onChange,
       onReady,
@@ -125,10 +124,6 @@ export default class EmberFlatpickr extends Component {
     });
 
     this._setDisabled(disabled);
-
-    if (getFlatpickrRef instanceof Function) {
-      getFlatpickrRef(this.flatpickrRef);
-    }
   }
 
   _setDisabled(disabled) {

--- a/addon/components/ember-flatpickr.js
+++ b/addon/components/ember-flatpickr.js
@@ -37,8 +37,11 @@ import { getOwner } from '@ember/application';
  * @uses Flatpickr
  */
 export default class EmberFlatpickr extends Component {
-  flatpickrRef = null;
   field = null;
+
+  get flatpickrRef() {
+    return this.field && this.field._flatpickr ? this.field._flatpickr : null;
+  }
 
   /**
    * The date(s) that will be used to initialize the flatpickr.  When present, the date(s) will
@@ -71,7 +74,7 @@ export default class EmberFlatpickr extends Component {
 
   @action
   onWillDestroy() {
-    this.field._flatpickr.destroy();
+    this.flatpickrRef.destroy();
   }
 
   setupFlatpickr() {
@@ -118,7 +121,7 @@ export default class EmberFlatpickr extends Component {
       ...rest
     } = this.args;
 
-    this.flatpickrRef = flatpickr(this.field, {
+    const flatpickrRef = flatpickr(this.field, {
       defaultDate: date,
       onChange,
       onClose: onClose || this.onClose,
@@ -134,16 +137,18 @@ export default class EmberFlatpickr extends Component {
     this._setDisabled(disabled);
 
     if (getFlatpickrRef instanceof Function) {
-      getFlatpickrRef(this.flatpickrRef);
+      getFlatpickrRef(flatpickrRef);
     }
   }
 
   _setDisabled(disabled) {
-    if (!this.flatpickrRef) {
+    const flatpickrRef = this.flatpickrRef;
+
+    if (!flatpickrRef) {
       return;
     }
 
-    if (this.flatpickrRef.altInput) {
+    if (flatpickrRef.altInput) {
       // `this.field` is the hidden input storing the alternate date value sent to the server
       // @see https://flatpickr.js.org/options/ `altInput` config options
       // Refactored during https://github.com/shipshapecode/ember-flatpickr/issues/306 to instead
@@ -206,18 +211,19 @@ export default class EmberFlatpickr extends Component {
 
   @action
   onAltFormatUpdated() {
-    this.field._flatpickr.set('altFormat', this.args.altFormat);
+    this.flatpickrRef.set('altFormat', this.args.altFormat);
   }
 
   @action
   onAltInputClassUpdated() {
     const { altInputClass } = this.args;
+    const flatpickrRef = this.flatpickrRef;
 
     // updating config anyways, just to keep them in sync:
-    this.field._flatpickr.set('altInputClass', altInputClass || '');
+    flatpickrRef.set('altInputClass', altInputClass || '');
 
     // https://github.com/flatpickr/flatpickr/issues/861
-    const { altInput } = this.field._flatpickr;
+    const { altInput } = flatpickrRef;
 
     if (altInput) {
       altInput.className = altInputClass || '';
@@ -229,7 +235,7 @@ export default class EmberFlatpickr extends Component {
     const { date } = this.args;
 
     if (typeof date !== 'undefined') {
-      this.field._flatpickr.setDate(date);
+      this.flatpickrRef.setDate(date);
     }
   }
 
@@ -244,17 +250,17 @@ export default class EmberFlatpickr extends Component {
 
   @action
   onLocaleUpdated() {
-    this.field._flatpickr.destroy();
+    this.flatpickrRef.destroy();
     this.setupFlatpickr();
   }
 
   @action
   onMaxDateUpdated() {
-    this.field._flatpickr.set('maxDate', this.args.maxDate);
+    this.flatpickrRef.set('maxDate', this.args.maxDate);
   }
 
   @action
   onMinDateUpdated() {
-    this.field._flatpickr.set('minDate', this.args.minDate);
+    this.flatpickrRef.set('minDate', this.args.minDate);
   }
 }

--- a/addon/components/ember-flatpickr.js
+++ b/addon/components/ember-flatpickr.js
@@ -28,7 +28,7 @@ import { getOwner } from '@ember/application';
  *    aria-describedby="described by"
  *    placeholder="Pick a date"
  *    @date={{model.someDate}}
- *    @onChange={{this.onChange}}
+ *    @onChange={{this.onChange}} />
  * ```
  *
  * @class EmberFlatpickr
@@ -37,7 +37,6 @@ import { getOwner } from '@ember/application';
  * @uses Flatpickr
  */
 export default class EmberFlatpickr extends Component {
-  date = null;
   flatpickrRef = null;
   field = null;
 

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@ember/render-modifiers": "^1.0.2",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-htmlbars": "^5.2.0",
     "ember-cli-node-assets": "^0.2.2",
-    "@ember/render-modifiers": "^1.0.2",
     "fastboot-transform": "^0.1.3",
-    "flatpickr": "4.6.3"
+    "flatpickr": "4.6.6"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",

--- a/tests/dummy/app/templates/docs/components/ember-flatpickr.md
+++ b/tests/dummy/app/templates/docs/components/ember-flatpickr.md
@@ -6,7 +6,6 @@
   <demo.example @name="date-time-picker.hbs">
     <EmberFlatpickr
       @allowInput={{true}}
-      @appendDataInput={{true}}
       @date={{this.dateValue}}
       @enableTime={{true}}
       @locale={{this.locale}}
@@ -56,7 +55,6 @@
   <demo.example @name="range-date-time-picker.hbs">
     <EmberFlatpickr
       @allowInput={{true}}
-      @appendDataInput={{true}}
       @date={{this.dateRangeValue}}
       @enableTime={{true}}
       @locale={{this.locale}}
@@ -106,7 +104,6 @@
 <DocsDemo as |demo|>
   <demo.example @name="time-picker.hbs">
     <EmberFlatpickr
-      @appendDataInput={{true}}
       @date={{this.timeValue}}
       @enableTime={{true}}
       @locale={{this.locale}}

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -17,7 +17,6 @@
   @enable={{this.datesToEnable}}
   @enableSeconds={{false}}
   @enableTime={{true}}
-  @getFlatpickrRef={{this.setFlatpickrRef}}  {{!-- via action (prefered) --}}
   @hourIncrement={{1}}
   @inline={{false}}
   @locale="ru"
@@ -30,7 +29,7 @@
   @onChange={{this.onChange}} {{!-- Required Option --}}
   @onClose={{this.onClose}}
   @onOpen={{this.onOpen}}
-  @onReady={{this.onReady}}
+  @onReady={{this.onReady}} {{!-- Can be used to easily store a reference to the flatpickr input. --}}
   @parseDate={{false}}
   placeholder="Choose a Date"
   @prevArrow="<"
@@ -144,7 +143,18 @@ Check [flatpickr locale documentation](https://chmln.github.io/flatpickr/#locale
 
 ## flatpickrRef
 
-If you need to interact directly with the flatpickr instance you have created inside the component, you can use the action `getFlatpickrRef` as `getFlatpickrRef={{this.setFlatpickrRef}}`, which would then be accesible in the controller or parent component. You can then do things like `this.get('myFlatpickrRefName').close()` to close the datepicker, if you wanted to make a close button.
+If you need to interact directly with the flatpickr instance you have created inside the component, you can use the action `onReady` as `onReady={{this.onReady}}`. The function signature of your onReady callback should look like the following example:
+
+```javascript
+@action
+onReady(_selectedDates, _dateStr, instance) {
+  this.flatpickrRef = instance;
+};
+```
+
+This action will only get called once per instance and that is when the flatpickr input has been fully created.
+
+Once you have stored the instance, you can then do things like `this.get('myFlatpickrRefName').close()` to close the datepicker, if you wanted to make a close button.
 
 ## Options
 
@@ -158,7 +168,7 @@ The wrap option for flatpickr causes flatpickr to search its child elements for 
 <EmberFlatpickr
   @date={{this.date}}
   @onChange={{this.onChange}}
-  @getFlatpickrRef={{this.setFlatpickrRef}}
+  @onReady={{this.onReady}}
 />
 
 <a class="input-button" title="toggle" {{on "click" this.toggleCalendar}}>

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -154,7 +154,7 @@ onReady(_selectedDates, _dateStr, instance) {
 
 This action will only get called once per instance and that is when the flatpickr input has been fully created.
 
-Once you have stored the instance, you can then do things like `this.get('myFlatpickrRefName').close()` to close the datepicker, if you wanted to make a close button.
+Once you have stored the instance, you can then do things like `this.flatpickrRef.close()` to close the datepicker, if you wanted to make a close button.
 
 ## Options
 

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -9,16 +9,16 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   const clickDay = async (index) => {
     await triggerEvent(
       findAll('.flatpickr-days .flatpickr-day')[index],
-      'mousedown'
+      'click'
     );
   };
 
   const openFlatpickr = async () => {
-    await triggerEvent(find('.flatpickr-input'), 'focus');
+    await triggerEvent(find('.flatpickr-input'), 'click');
   };
 
   const closeFlatpickr = async () => {
-    await triggerEvent(document.body, 'mousedown');
+    await triggerEvent(document.body, 'click');
   };
 
   test('when rendering with angle brackets', async function (assert) {

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -480,6 +480,36 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     );
   });
 
+  test('onLocaleUpdated fired', async function (assert) {
+    assert.expect(1);
+
+    this.set('dateValue', '2080-12-01T16:16:22.585Z');
+    this.set('maxDate', '2080-12-31T16:16:22.585Z');
+    this.set('minDate', '2080-12-01T16:16:22.585Z');
+    this.set('locale', 'fr');
+
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
+      @locale={{this.locale}}
+      @maxDate={{this.maxDate}}
+      @minDate={{this.minDate}}
+      @onChange={{null}}
+      placeholder="Pick date"
+    />`);
+
+    this.set('locale', 'ru');
+
+    await openFlatpickr();
+
+    assert.equal(
+      find(
+        '.flatpickr-current-month .flatpickr-monthDropdown-month'
+      ).textContent.trim(),
+      'Декабрь',
+      'Russian locale applied successfully'
+    );
+  });
+
   test('onChange triggers value change only once', async function (assert) {
     assert.expect(3);
 

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -313,20 +313,20 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     );
   });
 
-  test('flatpickrRef is accessible via action', async function (assert) {
+  test('The onReady callback can used as a mechanism for storing a reference to the flatpickr input.', async function (assert) {
     assert.expect(1);
 
-    const setFlatPickerRef = (instance) => {
+    const onReady = (_selectedDates, _dateStr, instance) => {
       this.set('flatpickrRef', instance);
     };
 
     this.set('dateValue', '2080-12-01T16:16:22.585Z');
-    this.set('setFlatPickerRef', setFlatPickerRef);
+    this.set('onReady', onReady);
 
     await render(hbs`<EmberFlatpickr
       @date={{this.dateValue}}
       @onChange={{null}}
-      @getFlatpickrRef={{this.setFlatPickerRef}}
+      @onReady={{this.onReady}}
       placeholder="Pick date"
     />`);
 
@@ -336,21 +336,21 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('value updates when set externally via flatpickrRef', async function (assert) {
     assert.expect(2);
 
-    const setFlatPickerRef = (instance) => {
+    const onReady = (_selectedDates, _dateStr, instance) => {
       this.set('flatpickrRef', instance);
     };
 
     this.set('dateValue', '2080-12-01T16:16:22.585Z');
     this.set('maxDate', '2080-12-31T16:16:22.585Z');
     this.set('minDate', '2080-12-01T16:16:22.585Z');
-    this.set('setFlatPickerRef', setFlatPickerRef);
+    this.set('onReady', onReady);
 
     await render(hbs`<EmberFlatpickr
         @date={{this.dateValue}}
-        @getFlatpickrRef={{this.setFlatPickerRef}}
         @maxDate={{this.maxDate}}
         @minDate={{this.minDate}}
         @onChange={{null}}
+        @onReady={{this.onReady}}
         placeholder="Pick date"
     />`);
 
@@ -658,17 +658,17 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     assert.expect(2);
 
     const originalDate = '2080-12-05T20:00:00.000Z';
-    const setFlatPickerRef = (instance) => {
+    const onReady = (_selectedDates, _dateStr, instance) => {
       this.set('flatpickrRef', instance);
     };
 
-    this.set('setFlatPickerRef', setFlatPickerRef);
+    this.set('onReady', onReady);
     this.set('dateValue', originalDate);
 
     await render(hbs`<EmberFlatpickr
       @date={{this.dateValue}}
       @onChange={{null}}
-      @getFlatpickrRef={{this.setFlatPickerRef}}
+      @onReady={{this.onReady}}
       placeholder="Pick date"
     />`);
 
@@ -689,17 +689,17 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     assert.expect(2);
 
     const originalDate = '2080-12-05T20:00:00.000Z';
-    const setFlatPickerRef = (instance) => {
+    const onReady = (_selectedDates, _dateStr, instance) => {
       this.set('flatpickrRef', instance);
     };
 
-    this.set('setFlatPickerRef', setFlatPickerRef);
+    this.set('onReady', onReady);
     this.set('dateValue', new Date(originalDate));
 
     await render(hbs`<EmberFlatpickr
       @date={{this.dateValue}}
       @onChange={{null}}
-      @getFlatpickrRef={{this.setFlatPickerRef}}
+      @onReady={{this.onReady}}
       placeholder="Pick date"
     />`);
 
@@ -719,17 +719,17 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     assert.expect(2);
 
     const originalDate = '2080-12-05T20:00:00.000Z';
-    const setFlatPickerRef = (instance) => {
+    const onReady = (_selectedDates, _dateStr, instance) => {
       this.set('flatpickrRef', instance);
     };
 
-    this.set('setFlatPickerRef', setFlatPickerRef);
+    this.set('onReady', onReady);
     this.set('dateValue', [originalDate]);
 
     await render(hbs`<EmberFlatpickr
       @date={{this.dateValue}}
       @onChange={{null}}
-      @getFlatpickrRef={{this.setFlatPickerRef}}
+      @onReady={{this.onReady}}
       placeholder="Pick date"
     />`);
 
@@ -750,17 +750,17 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     assert.expect(2);
 
     const originalDate = '2080-12-05T20:00:00.000Z';
-    const setFlatPickerRef = (instance) => {
+    const onReady = (_selectedDates, _dateStr, instance) => {
       this.set('flatpickrRef', instance);
     };
 
-    this.set('setFlatPickerRef', setFlatPickerRef);
+    this.set('onReady', onReady);
     this.set('dateValue', [new Date(originalDate)]);
 
     await render(hbs`<EmberFlatpickr
       @date={{this.dateValue}}
       @onChange={{null}}
-      @getFlatpickrRef={{this.setFlatPickerRef}}
+      @onReady={{this.onReady}}
       placeholder="Pick date"
     />`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8063,10 +8063,10 @@ flat@^4.1.0:
   dependencies:
     is-buffer "~2.0.3"
 
-flatpickr@4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.3.tgz#15a8b76b6e34e3a072861250503a5995b9d3bc60"
-  integrity sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ==
+flatpickr@4.6.6:
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.6.tgz#34d2ad80adfa34254e62583a34264d472f1038d6"
+  integrity sha512-EZ48CJMttMg3maMhJoX+GvTuuEhX/RbA1YeuI19attP3pwBdbYy6+yqAEVm0o0hSBFYBiLbVxscLW6gJXq6H3A==
 
 flatted@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
Updated `flatpickr` to v4.6.6, fix failing tests by changing all `mousedown` events to `click` events, and removed the `date` class property as it is not being used anywhere in the class. The actual date object is in the `this.args` object.