### PR TITLE
[docs] Updated documentation regarding external elements

### DIFF
--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -166,7 +166,7 @@ The wrap option for flatpickr causes flatpickr to search its child elements for 
 
 
 ```handlebars
-<!-- components/my-date-picker.hbs -->
+{{!-- components/my-date-picker.hbs --}}
 
 <EmberFlatpickr
   @date={{this.date}}

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -215,7 +215,7 @@ export default MyDatePicker extends Component {
 ```
 
 **Note:** In the above example, the `toggleCalendar` and `clearCalendar` actions
-receive an argument `e` (the click event) and call `e.stopPropagation` on said event. FlatPickr
+receive an argument `e` (the click event) and call `e.stopPropagation` on said event. flatpickr
 is designed to immediately close the calendar popup when user clicks outside of its bounding DOM element. Clicking the above _toggle_ button will call the "open" method on the flatpickr instance, but since our button lives outside of the bounds of the picker's calendar, flatpickr immediately closes the calendar popup. By stopping the propagation of our external click event, flatpickr does not detect the outside click and the calendar opens as expected.
 
 

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -216,7 +216,7 @@ export default MyDatePicker extends Component {
 
 **Note:** In the above example, the `toggleCalendar` and `clearCalendar` actions
 receive an argument `e` (the click event) and call `e.stopPropagation` on said event. FlatPickr
-is designed to immediately close the calendar popup when user's click outside of it's bounding DOM element. Clicking the above _toggle_ button will call the "open" method on the FlatPickr instance, but since our button lives outside of the bounds of the pickr's calendar, FlatPickr immediately closes the calendar popup. By stopping the propagation of our external click event, FlatPickr does not detect the outside click and the calendar opens as expected.
+is designed to immediately close the calendar popup when user clicks outside of its bounding DOM element. Clicking the above _toggle_ button will call the "open" method on the flatpickr instance, but since our button lives outside of the bounds of the picker's calendar, flatpickr immediately closes the calendar popup. By stopping the propagation of our external click event, flatpickr does not detect the outside click and the calendar opens as expected.
 
 
 Please see the [flatpickr docs](https://chmln.github.io/flatpickr/) for a full list of options.

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -164,7 +164,10 @@ All options available to Flatpickr are available here with the exception of wrap
 
 The wrap option for flatpickr causes flatpickr to search its child elements for elements annotated with certain attributes. With ember-flatpickr this can be accomplished with the following
 
+
 ```handlebars
+<!-- components/my-date-picker.hbs -->
+
 <EmberFlatpickr
   @date={{this.date}}
   @onChange={{this.onChange}}
@@ -181,15 +184,39 @@ The wrap option for flatpickr causes flatpickr to search its child elements for 
 ```
 
 ```javascript
-@action
-toggleCalendar() {
-  this.flatpickrRef.toggle();
-}
+// components/my-date-picker.js
 
-@action
-clearCalendar() {
-  this.flatpickrRef.clear();
+import Component from '@glimmer/component'
+import { tracked } from '@glimmer/tracking'
+import { action } from '@ember/object'
+
+export default MyDatePicker extends Component {
+
+  @tracked flatpickrRef = null
+
+  @action
+  onReady(_selectedDates, _dateStr, flatpickrRef) {
+    this.flatpickrRef = flatpickrRef
+  }
+
+  @action
+  toggleCalendar(e) {
+    e.stopPropagation()
+    this.flatpickrRef.toggle();
+  }
+
+  @action
+  clearCalendar(e) {
+    e.stopPropagation()
+    this.flatpickrRef.clear();
+  }
+
 }
 ```
+
+**Note:** In the above example, the `toggleCalendar` and `clearCalendar` actions
+receive an argument `e` (the click event) and call `e.stopPropagation` on said event. FlatPickr
+is designed to immediately close the calendar popup when user's click outside of it's bounding DOM element. Clicking the above _toggle_ button will call the "open" method on the FlatPickr instance, but since our button lives outside of the bounds of the pickr's calendar, FlatPickr immediately closes the calendar popup. By stopping the propagation of our external click event, FlatPickr does not detect the outside click and the calendar opens as expected.
+
 
 Please see the [flatpickr docs](https://chmln.github.io/flatpickr/) for a full list of options.


### PR DESCRIPTION
 updated the documentation example surrounding external elements noting that users will need to stopPropagation on click events in order for FlatPickr to properly open the calendar popup