### PR TITLE
Don't pass undefined arguments through to Flatpickr config

### DIFF
--- a/addon/components/ember-flatpickr.ts
+++ b/addon/components/ember-flatpickr.ts
@@ -121,12 +121,16 @@ export default class EmberFlatpickr extends Component<EmberFlatpickrArgs> {
       ...rest
     } = this.args;
 
+    const config: Partial<FlatpickrOptions> = Object.fromEntries(
+      Object.entries(rest).filter((entry) => entry[1] !== undefined)
+    );
+
     this.flatpickrRef = flatpickr(element, {
       onChange,
       onClose: onClose || this.onClose,
       onOpen: onOpen || this.onOpen,
       onReady: onReady || this.onReady,
-      ...rest,
+      ...config,
       defaultDate: date
     });
 

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -787,4 +787,28 @@ module('Integration | Component | ember flatpickr', function (hooks) {
       'selected date is correct'
     );
   });
+
+  test('it will not override Flatpickr defaults with undefined', async function (assert) {
+    const onReady = (_selectedDates, _dateStr, instance) => {
+      this.set('flatpickrRef', instance);
+    };
+
+    this.set('dateValue', '2080-12-01T16:16:22.585Z');
+    this.set('onReady', onReady);
+
+    await render(
+      hbs`<EmberFlatpickr
+        @date={{this.dateValue}}
+        @onChange={{null}}
+        @onReady={{this.onReady}}
+        @disable={{undefined}}
+      />`
+    );
+
+    assert.deepEqual(
+      this.flatpickrRef.config.disable,
+      [],
+      'disable config was not overwritten'
+    );
+  });
 });

--- a/tests/integration/components/ember-flatpickr-test.js
+++ b/tests/integration/components/ember-flatpickr-test.js
@@ -34,8 +34,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     this.set('dateValue', [new Date(2001, 8, 11)]);
 
     await render(
-      hbs`<EmberFlatpickr 
-        @date={{this.dateValue}} 
+      hbs`<EmberFlatpickr
+        @date={{this.dateValue}}
         @onChange={{null}}/>`
     );
 
@@ -46,8 +46,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding aria-activedescendent attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
-      @date={{this.dateValue}} 
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
       @onChange={{null}}
       aria-activedescendent="aria-activedescendent"
     />`);
@@ -62,8 +62,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding aria-autocomplete attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
-      @date={{this.dateValue}} 
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
       @onChange={{null}}
       aria-autocomplete="aria-autocomplete"
     />`);
@@ -78,8 +78,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding aria-describedby attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
-      @date={{this.dateValue}} 
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
       @onChange={{null}}
       aria-describedby="described by"
     />`);
@@ -94,8 +94,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding aria-labelledby attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
-      @date={{this.dateValue}} 
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
       @onChange={{null}}
       aria-labelledby="aria-labelledby"
     />`);
@@ -110,8 +110,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding aria-multiline attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
-      @date={{this.dateValue}} 
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
       @onChange={{null}}
       aria-multiline="aria-multiline"
     />`);
@@ -126,8 +126,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding aria-placeholder attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
-      @date={{this.dateValue}} 
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
       @onChange={{null}}
       aria-placeholder="aria-placeholder"
     />`);
@@ -142,8 +142,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding aria- attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
-      @date={{this.dateValue}} 
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
       @onChange={{null}}
       aria-="aria-"
     />`);
@@ -155,8 +155,8 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding aria-required attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
-      @date={{this.dateValue}} 
+    await render(hbs`<EmberFlatpickr
+      @date={{this.dateValue}}
       @onChange={{null}}
       aria-required="aria-required"
     />`);
@@ -171,7 +171,7 @@ module('Integration | Component | ember flatpickr', function (hooks) {
   test('when adding a title attribute it is assigned to the picker input', async function (assert) {
     this.set('dateValue', [new Date()]);
 
-    await render(hbs`<EmberFlatpickr 
+    await render(hbs`<EmberFlatpickr
       @date={{this.dateValue}}
       @onChange={{null}}
       title="Choose a date"
@@ -191,11 +191,11 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     this.set('dateValue', [new Date(originalDate)]);
     this.set('disabled', true);
 
-    await render(hbs`<EmberFlatpickr 
-      @altInput={{true}} 
+    await render(hbs`<EmberFlatpickr
+      @altInput={{true}}
       @date={{this.dateValue}}
-      @onChange={{null}} 
-      @disabled={{this.disabled}} 
+      @onChange={{null}}
+      @disabled={{this.disabled}}
       placeholder="Pick date"
     />`);
 
@@ -233,10 +233,10 @@ module('Integration | Component | ember flatpickr', function (hooks) {
     this.set('dateValue', [new Date(originalDate)]);
     this.set('disabled', true);
 
-    await render(hbs`<EmberFlatpickr 
-      @altInput={{false}} 
-      @date={{this.dateValue}} 
-      @disabled={{disabled}} 
+    await render(hbs`<EmberFlatpickr
+      @altInput={{false}}
+      @date={{this.dateValue}}
+      @disabled={{disabled}}
       @onChange={{null}} placeholder="Pick date"
      />`);
 


### PR DESCRIPTION
## The problem

We would like to wrap `<EmberFlatpickr>` in a component to DRY up some of the config options that we pass to every instance. Because Ember doesn't have "splargs" (a la splattributes), this means we end up having to pass through every possible Ember Flatpickr arg like so:

```hbs
<EmberFlatpickr
  class="w-full block border-2 p-3 mb-2"
  placeholder="Choose a date"
  ...attributes
  @allowInput={{or-default @allowInput true}}
  @altFormat={{@altFormat}}
  @altInput={{or-default @altInput true}}
  @altInputClass={{@altInputClass}}
  @clickOpens={{@clickOpens}}
  @date={{@date}}
  @dateFormat={{@dateFormat}}
  @defaultDate={{@defaultDate}}
  @defaultHour={{@defaultHour}}
  @defaultMinute={{@defaultMinute}}
  @disable={{@disable}}
  @disabled={{@disabled}}
  @disableMobile={{@disableMobile}}
  @enable={{@enable}}
  @enableSeconds={{@enableSeconds}}
  @enableTime={{@enableTime}}
  @hourIncrement={{@hourIncrement}}
  @inline={{@inline}}
  @locale={{@locale}}
  @maxDate={{@maxDate}}
  @minDate={{@minDate}}
  @minuteIncrement={{@minuteIncrement}}
  @mode={{@mode}}
  @monthSelectorType={{or-default @monthSelectorType 'static'}}
  @nextArrow={{@nextArrow}}
  @noCalendar={{@noCalendar}}
  @onChange={{@onChange}}
  @onClose={{@onClose}}
  @onOpen={{@onOpen}}
  @onReady={{@onReady}}
  @parseDate={{or-default @parseDate this.parseDate}}
  @prevArrow={{@prevArrow}}
  @shorthandCurrentMonth={{@shorthandCurrentMonth}}
  @static={{@static}}
  @time_24hr={{@time_24hr}}
  @weekNumbers={{@weekNumbers}}
/>
```

Even when an argument is `undefined`, Ember still passes it through. Thus, Ember Flatpickr passes `undefined` into the `flatpickr` function. Eventually, this makes its way to this line in Flatpickr:

https://github.com/flatpickr/flatpickr/blob/07cf1b1ba5ec71da511c295f622d60eed3bf3eb7/src/index.ts#L2039

`Object.assign` will overwrite all named properties from the target object even if the value is `undefined`, so this overwrites the default config with invalid `undefined` config. Eventually, this results in type errors while trying to initialize the Flatpickr object. For example, this is the error thrown in my "it will not override Flatpickr defaults with undefined" test if you remove the code that fixes the issue in `_setFlatpickrOptions`:

```
            TypeError: Cannot set property 'disabled' of undefined
                at EmberFlatpickr._setDisabled (http://localhost:7357/assets/vendor.js:122353:26)
                at EmberFlatpickr._setFlatpickrOptions (http://localhost:7357/assets/vendor.js:122333:12)
                at invoke (http://localhost:7357/assets/vendor.js:59886:16)
                at Queue.flush (http://localhost:7357/assets/vendor.js:59775:13)
                at DeferredActionQueues.flush (http://localhost:7357/assets/vendor.js:59972:21)
                at Backburner._end (http://localhost:7357/assets/vendor.js:60506:34)
                at Backburner._boundAutorunEnd (http://localhost:7357/assets/vendor.js:60175:14)
```

## My solution

Filter `undefined` values from the config object before passing it through to the `flatpickr` function. For the most part, `undefined` seems to be an invalid config option in Flatpickr (per https://flatpickr.js.org/options/), with `null` preferred for turning things "off." The one exception seems to be the `enable` property, which defaults to `undefined` (so not passing in `undefined` to override `undefined` is probably OK.)

## Other notes

* There seems to be a failing test on master (at least when I run them locally). This PR does not fix that failing test.
* When I tried to `yarn install`, I got an error because one of the dependencies has deprecated Node 10, which is what's specified in the volta config for this project. To fix, I upgraded node for the project locally but did not commit this change.