### PR TITLE
Fix broken "Edit this page" link in docs

### DIFF
--- a/config/addon-docs.js
+++ b/config/addon-docs.js
@@ -6,4 +6,8 @@ const AddonDocsConfig = require('ember-cli-addon-docs/lib/config');
 module.exports = class extends AddonDocsConfig {
   // See https://ember-learn.github.io/ember-cli-addon-docs/docs/deploying
   // for details on configuration you can override here.
+  
+  getPrimaryBranch() {
+    return "main";
+  },
 };


### PR DESCRIPTION
The "Edit this page" link in the docs currently links to the broken link:
```
https://github.com/shipshapecode/ember-flatpickr/edit/master/tests/dummy/app/templates/docs/index.md
                                                      ^^^^^^
```
It **should** link to:
```
https://github.com/shipshapecode/ember-flatpickr/edit/main/tests/dummy/app/templates/docs/index.md
                                                      ^^^^
```

Fix to use [getPrimaryBranch](https://github.com/ember-learn/ember-cli-addon-docs/blob/master/tests/dummy/app/templates/docs/deploying.md#getprimarybranch) to specify that we're using main, not master.