### PR TITLE
feat: let host decide flatpickr to use

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "broccoli-stew": "^3.0.0",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
-    "ember-cli-typescript": "^5.0.0",
-    "flatpickr": "^4.6.9"
+    "ember-cli-typescript": "^5.0.0"
   },
   "devDependencies": {
+    "flatpickr": "^4.6.9",
     "@babel/core": "^7.0.0-0",
     "@babel/eslint-parser": "^7.21.3",
     "@babel/plugin-proposal-decorators": "^7.21.0",
@@ -132,7 +132,13 @@
     "colors": "1.4.0"
   },
   "peerDependencies": {
+    "flatpickr": "^4.6.9",
     "ember-source": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@glimmer/component": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
Basically I needed to depend on a fork of flatpickr, I guess moving forward most wrappers addons should have the underlaying dep as peerDependency, what do you think? also, the peerDependenciesMeta is something that pnpm exposes as an option https://pnpm.io/package_json#peerdependenciesmetaoptional