### PR TITLE
Make base class generic

### DIFF
--- a/addon/components/ember-flatpickr.ts
+++ b/addon/components/ember-flatpickr.ts
@@ -43,7 +43,7 @@ interface EmberFlatpickrArgs extends FlatpickrOptions {
  * @public
  * @uses Flatpickr
  */
-export default class EmberFlatpickr extends Component<EmberFlatpickrArgs> {
+export default class EmberFlatpickr<T extends EmberFlatpickrArgs = EmberFlatpickrArgs>  extends Component<T> {
   flatpickrRef?: FlatpickrInstance;
 
   /**


### PR DESCRIPTION
In order to support it to be extended to override hooks like onClose, onOpen... a generic interface is needed to pass more args, what do you think?